### PR TITLE
#511 - Fixed problem with TargetController fetching a Subject by refe…

### DIFF
--- a/app/controllers/TargetController.java
+++ b/app/controllers/TargetController.java
@@ -591,7 +591,7 @@ public class TargetController extends AbstractController {
         Logger.debug("Targets.subjectTargets()");
         return ok(
                 views.html.subjects.sites.render(
-                        Taxonomy.findById(subjectId),
+                        Subject.findById(subjectId),
                         User.findByEmail(request().username()),
                         filter,
                         Target.pageSubjectTargets(pageNo, 10, sortBy, order, filter, subjectId),


### PR DESCRIPTION
This was caused by the controller method fetching the Subject entity using a find method in its base class, Taxonomy, rather than in the Subject class itself. 

The entities use the single table inheritance model, which requires the use of a discriminator column and unique value for each derived class. By using the find method in the base class rather than the correct derived class, the EBeans framework did not know which discriminator value to use in its database query to fetch the row. Really, it could simply not use a discriminator at all in this instance, however EBeans appears to not properly support this situation, and was attempting to fetch the Subject entity using the discriminator value appropriate for fetching a Collection entity instead (perhaps because it has the lowest of the discriminator values for this table, 1?). The result was a NullPointerException further down the line where a property that should have contained an entity didn't. 